### PR TITLE
fix: don't throw on invalid Dates when serializing the cache

### DIFF
--- a/components/TreeView.tsx
+++ b/components/TreeView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { ChevronRight, Trash2, Copy, Check, ListX } from "lucide-react";
-import { serializeToJsLiteral } from "@/utils/serialization";
+import { dateToWireString, serializeToJsLiteral } from "@/utils/serialization";
 import type { PathSegment } from "@/types/messages";
 
 interface TreeViewProps {
@@ -266,7 +266,7 @@ export function TreeView({ data, label, depth = 0, ancestors = new Set(), editab
     return (
       <div className="flex items-center">
         {labelSpan}
-        <span className="flex-1 truncate min-w-10 text-blue-600 dark:text-blue-400">{data.toISOString()}</span>
+        <span className="flex-1 truncate min-w-10 text-blue-600 dark:text-blue-400">{dateToWireString(data)}</span>
         {deleteBtn}
       </div>
     );

--- a/utils/serialization.ts
+++ b/utils/serialization.ts
@@ -6,6 +6,30 @@ interface TypeSentinel {
 
 type WriteTarget = Record<string, unknown> | unknown[];
 
+/**
+ * `new Date("nope")` is still `instanceof Date`, but its time value is NaN and
+ * `toISOString()` throws `RangeError: Invalid time value` on it. Any invalid
+ * Date anywhere in the inspected cache would therefore make serialization throw.
+ *
+ * That is not contained to the panel: `entrypoints/sync.js` runs in the page's
+ * MAIN world as a QueryCache subscriber, and `QueryCache.notify` iterates its
+ * subscribers without catching. The RangeError unwinds out of the host
+ * application's own React render/commit and trips its error boundary, so a
+ * single invalid Date in the cache takes the inspected app down.
+ *
+ * `"Invalid Date"` is used as the wire value because `new Date("Invalid Date")`
+ * decodes back to an equally invalid Date, keeping the round-trip faithful.
+ */
+export const INVALID_DATE_LABEL = "Invalid Date";
+
+export function isInvalidDate(date: Date): boolean {
+  return Number.isNaN(date.getTime());
+}
+
+export function dateToWireString(date: Date): string {
+  return isInvalidDate(date) ? INVALID_DATE_LABEL : date.toISOString();
+}
+
 function writeSlot(target: WriteTarget, key: string | number, val: unknown): void {
   if (typeof key === "number") {
     (target as unknown[])[key] = val;
@@ -59,7 +83,7 @@ export function encodeBigInts(value: unknown): unknown {
     seen.add(obj);
 
     if (obj instanceof Date) {
-      writeSlot(frame.target, frame.key, { __tqcd_type: "date", value: obj.toISOString() } as TypeSentinel);
+      writeSlot(frame.target, frame.key, { __tqcd_type: "date", value: dateToWireString(obj) } as TypeSentinel);
       continue;
     }
 
@@ -241,7 +265,7 @@ function prepareForStringify(value: unknown): unknown {
   if (typeof value === "bigint") return `__bigint:${String(value)}`;
   if (typeof value === "symbol") return `__symbol:${value.description ?? ""}`;
   if (typeof value === "function") return "__function";
-  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Date) return dateToWireString(value);
   if (value instanceof Map) {
     const result: Record<string, unknown> = {};
     for (const [k, v] of value.entries()) {
@@ -313,6 +337,9 @@ export function serializeToJsLiteral(
   if (ancestors.has(obj)) return '"[Circular]"';
 
   if (obj instanceof Date) {
+    // `new Date(NaN)` is the faithful literal for an invalid Date — emitting
+    // `new Date("Invalid Date")` would also work, but NaN states the intent.
+    if (isInvalidDate(obj)) return "new Date(NaN)";
     return `new Date("${obj.toISOString()}")`;
   }
 


### PR DESCRIPTION
## Summary

An invalid `Date` is still `instanceof Date`, but its time value is `NaN` and `toISOString()` throws `RangeError: Invalid time value` on it. Every `Date` branch in the serialization path called `toISOString()` unguarded, so a **single invalid Date anywhere in the inspected cache** made serialization throw.

The important part is where that exception lands. `sync.ts` is injected with `"world": "MAIN"`, so it subscribes to the page's real `QueryCache`. `QueryCache.notify` iterates its subscribers without catching, so the `RangeError` unwinds out of the **inspected application's** own React commit phase and trips its error boundary.

In other words: the devtools crash the app they are inspecting, and the app's stack trace points at whichever component happened to unmount, with no hint that an extension is involved. That took a while to track down on our side:

```
RangeError: Invalid time value
    at Date.toISOString (<anonymous>)
    at m (chrome-extension://annajfchloimdhceglpgglpeepfghfai/content-scripts/sync.js:1:746)
    at A (chrome-extension://annajfchloimdhceglpgglpeepfghfai/content-scripts/sync.js:1:4935)
    at ...
    at Set.forEach (<anonymous>)
    at Object.batch
    at QueryCache.notify
    at Query.removeObserver
```

It is also sticky — the bad entry stays in the cache, so every subsequent `notify` throws again until the `QueryClient` is torn down (for us, a logout/login).

## Changes

Adds a small guard used by all four `Date` sites, rather than fixing only the one that crashed:

- `utils/serialization.ts:62` — `encodeBigInts` (the deep walker; this is the one that crashed)
- `utils/serialization.ts:244` — `prepareForStringify`
- `utils/serialization.ts:316` — `serializeToJsLiteral`
- `components/TreeView.tsx:269` — panel rendering, which would throw for the same reason

Invalid Dates encode as the wire value `"Invalid Date"`, chosen because `new Date("Invalid Date")` decodes back to an equally invalid Date — so the existing `case "date"` decoder needs no change and the round-trip stays faithful. Export emits `new Date(NaN)`.

## Verification

`npm run compile` and `npm run lint` both clean. `npm run prettier:check` reports the same 50 pre-existing files before and after, so I left formatting alone rather than mixing an unrelated reformat into this diff.

The repo has no test runner, so I verified out-of-tree against these functions directly, with a `QueryCache`-shaped payload holding one invalid and one valid Date:

```
sanity: raw toISOString on an invalid Date
  confirmed baseline throw -> RangeError: Invalid time value

encode / decode round-trip
  PASS  encodeBigInts does not throw
  invalid encoded as: {"__tqcd_type":"date","value":"Invalid Date"}
  valid   encoded as: {"__tqcd_type":"date","value":"2026-04-07T12:00:00.000Z"}
  PASS  invalid Date decodes back to a Date instance
  PASS  invalid Date is still invalid after round-trip
  PASS  valid Date survives round-trip exactly

other serializers
  PASS  stringifyWithBigInt does not throw
  PASS  serializeToJsLiteral does not throw
  js literal for invalid: new Date(NaN)
  js literal for valid:   new Date("2026-04-07T12:00:00.000Z")
  PASS  emitted literal for invalid Date evals to an invalid Date
```

Against unmodified `main` the first check fails with exactly the reported `RangeError: Invalid time value`.

Happy to reshape any of this — including dropping the exported helpers for a plain inline guard, or emitting `null` instead of `"Invalid Date"` — if you'd prefer a different convention.